### PR TITLE
Add symbol search tool using VSCode's built-in symbol search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Before we embark on this magical journey, make sure you have:
 - 🔒 **Safe Operations** - Asks for your approval before making changes or running commands
 - 📚 **Workspace Awareness** - Can load your entire workspace for better context (configurable)
 - 📜 **Custom Rules** - Teach your AI companion your project's special needs
+- 🔍 **Symbol Search** - Find symbols in the code base and return relevant code snippets with line numbers
 
 ## 🚀 Installation
 
@@ -108,6 +109,11 @@ Cogent: "I'll analyze your code and suggest some improvements. Here's my plan...
 ```
 You: "@Cogent Create a new React component for user authentication"
 Cogent: "I'll help you create a secure authentication component. First, let me outline the structure..."
+```
+
+```
+You: "@Cogent Search for the symbol 'myFunction' in the code base"
+Cogent: "I'll search for the symbol 'myFunction' and return relevant code snippets with line numbers. Here's what I found..."
 ```
 
 ## 🎭 Behind the Scenes

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Before we embark on this magical journey, make sure you have:
 - 📚 **Workspace Awareness** - Can load your entire workspace for better context (configurable)
 - 📜 **Custom Rules** - Teach your AI companion your project's special needs
 - 🔍 **Symbol Search** - Find symbols in the code base and return relevant code snippets with line numbers
+- 🔍 **File Search** - Search for files by partial filename matching and return relevant file paths
 
 ## 🚀 Installation
 
@@ -114,6 +115,11 @@ Cogent: "I'll help you create a secure authentication component. First, let me o
 ```
 You: "@Cogent Search for the symbol 'myFunction' in the code base"
 Cogent: "I'll search for the symbol 'myFunction' and return relevant code snippets with line numbers. Here's what I found..."
+```
+
+```
+You: "@Cogent Search for files with the name 'utils'"
+Cogent: "I'll search for files with the name 'utils' and return relevant file paths. Here's what I found..."
 ```
 
 ## 🎭 Behind the Scenes

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Include full workspace content in the initial prompt. If disabled, files will be read on demand.\n\n Note: Not recommended for large workspaces."
+                },
+                "cogent.include_directory_structure": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include directory structure in the prompt. If disabled, directory structure will not be included."
                 }
             }
         },
@@ -129,6 +134,22 @@
                         }
                     },
                     "required": ["symbol"]
+                }
+            },
+            {
+                "name": "cogent_searchFile",
+                "tags": ["files", "search"],
+                "displayName": "Search File",
+                "modelDescription": "Search for files by partial filename matching and return relevant file paths",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "filename": {
+                            "type": "string",
+                            "description": "Filename to search for"
+                        }
+                    },
+                    "required": ["filename"]
                 }
             }
         ]

--- a/package.json
+++ b/package.json
@@ -114,6 +114,22 @@
                     },
                     "required": ["paths"]
                 }
+            },
+            {
+                "name": "cogent_searchSymbol",
+                "tags": ["files", "search"],
+                "displayName": "Search Symbol",
+                "modelDescription": "Search for symbols in the code base and return relevant code snippets with line numbers",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "symbol": {
+                            "type": "string",
+                            "description": "Symbol to search for"
+                        }
+                    },
+                    "required": ["symbol"]
+                }
             }
         ]
     },

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,0 +1,20 @@
+const vscode = require('vscode');
+const { SymbolSearchTool } = require('./tools/SymbolSearchTool');
+
+function activate(context) {
+    console.log('Cogent extension is now active!');
+
+    // Register tools
+    context.subscriptions.push(
+        vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool())
+    );
+}
+
+function deactivate() {
+    console.log('Cogent extension is now deactivated!');
+}
+
+module.exports = {
+    activate,
+    deactivate
+};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { registerToolUserChatParticipant } from './toolParticipant';
 import { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool } from './tools';
 import { DiffView } from './components/DiffView';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
+import { FileSearchTool } from './tools/FileSearchTool';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Cogent extension is now active!');
@@ -13,7 +14,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.lm.registerTool('cogent_writeFile', new FileWriteTool()),
         vscode.lm.registerTool('cogent_updateFile', new FileUpdateTool()),
         vscode.lm.registerTool('cogent_runCommand', new CommandRunTool()),
-        vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool())
+        vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool()),
+        vscode.lm.registerTool('cogent_searchFile', new FileSearchTool())
     );
     
     // Register the tool participant

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { registerToolUserChatParticipant } from './toolParticipant';
 import { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool } from './tools';
 import { DiffView } from './components/DiffView';
+import { SymbolSearchTool } from './tools/SymbolSearchTool';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Cogent extension is now active!');
@@ -11,7 +12,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.lm.registerTool('cogent_readFile', new FileReadTool()),
         vscode.lm.registerTool('cogent_writeFile', new FileWriteTool()),
         vscode.lm.registerTool('cogent_updateFile', new FileUpdateTool()),
-        vscode.lm.registerTool('cogent_runCommand', new CommandRunTool())
+        vscode.lm.registerTool('cogent_runCommand', new CommandRunTool()),
+        vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool())
     );
     
     // Register the tool participant

--- a/src/toolParticipant.ts
+++ b/src/toolParticipant.ts
@@ -93,6 +93,10 @@ export function registerToolUserChatParticipant(context: vscode.ExtensionContext
                         const input = part.input as { symbol: string };
                         stream.markdown(`\n\nSearching for symbol: ${input.symbol}`);
                     }
+                    if (part.name === 'cogent_searchFile') {
+                        const input = part.input as { filename: string };
+                        stream.markdown(`\n\nSearching for file: ${input.filename}`);
+                    }
                     toolCalls.push(part);
                 }
             }

--- a/src/toolParticipant.ts
+++ b/src/toolParticipant.ts
@@ -89,6 +89,10 @@ export function registerToolUserChatParticipant(context: vscode.ExtensionContext
                         const input = part.input as ReadFileToolInput;
                         stream.markdown(`\n\nReading files: ${JSON.stringify(input.paths)}`);
                     }
+                    if (part.name === 'cogent_searchSymbol') {
+                        const input = part.input as { symbol: string };
+                        stream.markdown(`\n\nSearching for symbol: ${input.symbol}`);
+                    }
                     toolCalls.push(part);
                 }
             }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,5 +3,6 @@ import { FileWriteTool } from './tools/FileWriteTool';
 import { FileUpdateTool } from './tools/FileUpdateTool';
 import { CommandRunTool } from './tools/CommandRunTool';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
+import { FileSearchTool } from './tools/FileSearchTool';
 
-export { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool, SymbolSearchTool };
+export { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool, SymbolSearchTool, FileSearchTool };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -2,5 +2,6 @@ import { FileReadTool } from './tools/FileReadTool';
 import { FileWriteTool } from './tools/FileWriteTool';
 import { FileUpdateTool } from './tools/FileUpdateTool';
 import { CommandRunTool } from './tools/CommandRunTool';
+import { SymbolSearchTool } from './tools/SymbolSearchTool';
 
-export { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool };
+export { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool, SymbolSearchTool };

--- a/src/tools/FileReadTool.ts
+++ b/src/tools/FileReadTool.ts
@@ -20,11 +20,11 @@ export class FileReadTool implements vscode.LanguageModelTool<IFileOperationPara
             }
 
             const filePaths = options.input.paths || (options.input.path ? [options.input.path] : []);
-            
+
             const results = await Promise.all(filePaths.map(async (filePath) => {
-                const fullPath = path.join(workspacePath, filePath);
+                //const fullPath = path.join(workspacePath, filePath);
                 try {
-                    const content = await fs.readFile(fullPath, 'utf-8');
+                    const content = await fs.readFile(filePath, 'utf-8');
                     return [
                         '=' .repeat(80),
                         `📝 File: ${filePath}`,

--- a/src/tools/FileSearchTool.ts
+++ b/src/tools/FileSearchTool.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+interface IFileSearchParams {
+    filename: string;
+}
+
+export class FileSearchTool implements vscode.LanguageModelTool<IFileSearchParams> {
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<IFileSearchParams>,
+        _token: vscode.CancellationToken
+    ) {
+        const filename = options.input.filename;
+        const results = await this.searchFilesInWorkspace(filename);
+
+        if (results.length === 0) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(`No files found for: ${filename}`)
+            ]);
+        }
+
+        return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(results.join('\n\n'))
+        ]);
+    }
+
+    private async searchFilesInWorkspace(filename: string): Promise<string[]> {
+        const results: string[] = [];
+        const workspaceFolders = vscode.workspace.workspaceFolders;
+
+        if (workspaceFolders) {
+            for (const folder of workspaceFolders) {
+                const folderPath = folder.uri.fsPath;
+                const files = await this.findFiles(folderPath, filename);
+                results.push(...files);
+            }
+        }
+
+        return results;
+    }
+
+    private async findFiles(dir: string, filename: string): Promise<string[]> {
+        const results: string[] = [];
+        const files = await fs.readdir(dir, { withFileTypes: true });
+
+        for (const file of files) {
+            const filePath = path.join(dir, file.name);
+
+            if (file.isDirectory()) {
+                const subDirResults = await this.findFiles(filePath, filename);
+                results.push(...subDirResults);
+            } else if (file.name.includes(filename)) {
+                results.push(filePath);
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/tools/FileUpdateTool.ts
+++ b/src/tools/FileUpdateTool.ts
@@ -24,12 +24,12 @@ export class FileUpdateTool implements vscode.LanguageModelTool<IFileOperationPa
             if (!options.input.path) {
                 throw new Error('File path is required');
             }
-            const filePath = path.join(workspacePath, options.input.path);
+            const filePath = options.input.path;
             const originalContent = await fs.readFile(filePath, 'utf-8');
-            
+
             this.diffView = new DiffView(filePath, originalContent);
             await this.diffView.show();
-            
+
             if (options.input.content) {
                 const lines = options.input.content.split('\n');
                 for (let i = 0; i < lines.length; i++) {

--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -23,12 +23,14 @@ export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchP
 
         if (symbolInfos) {
             for (const symbolInfo of symbolInfos) {
-                const document = await vscode.workspace.openTextDocument(symbolInfo.location.uri);
-                const symbolRange = symbolInfo.location.range;
-                const symbolText = document.getText(symbolRange);
-                const startLine = symbolRange.start.line + 1;
+                if (symbolInfo.name === symbol) {
+                    const document = await vscode.workspace.openTextDocument(symbolInfo.location.uri);
+                    const symbolRange = symbolInfo.location.range;
+                    const symbolText = document.getText(symbolRange);
+                    const startLine = symbolRange.start.line + 1;
 
-                results.push(`File: ${symbolInfo.location.uri.fsPath}\nLine ${startLine}:\n${symbolText}`);
+                    results.push(`File: ${symbolInfo.location.uri.fsPath}\nLine ${startLine}:\n${symbolText}`);
+                }
             }
         }
 

--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+
+interface ISymbolSearchParams {
+    symbol: string;
+}
+
+export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchParams> {
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<ISymbolSearchParams>,
+        _token: vscode.CancellationToken
+    ) {
+        const symbol = options.input.symbol;
+        const results = await this.searchSymbolInWorkspace(symbol);
+
+        return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(results.join('\n\n'))
+        ]);
+    }
+
+    private async searchSymbolInWorkspace(symbol: string): Promise<string[]> {
+        const results: string[] = [];
+        const symbolInfos = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeWorkspaceSymbolProvider', symbol);
+
+        if (symbolInfos) {
+            for (const symbolInfo of symbolInfos) {
+                const document = await vscode.workspace.openTextDocument(symbolInfo.location.uri);
+                const symbolRange = symbolInfo.range;
+                const symbolText = document.getText(symbolRange);
+                const startLine = symbolRange.start.line + 1;
+
+                results.push(`File: ${symbolInfo.location.uri.fsPath}\nLine ${startLine}:\n${symbolText}`);
+            }
+        }
+
+        return results;
+    }
+}

--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -19,12 +19,12 @@ export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchP
 
     private async searchSymbolInWorkspace(symbol: string): Promise<string[]> {
         const results: string[] = [];
-        const symbolInfos = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>('vscode.executeWorkspaceSymbolProvider', symbol);
+        const symbolInfos = await vscode.commands.executeCommand<vscode.SymbolInformation[]>('vscode.executeWorkspaceSymbolProvider', symbol);
 
         if (symbolInfos) {
             for (const symbolInfo of symbolInfos) {
                 const document = await vscode.workspace.openTextDocument(symbolInfo.location.uri);
-                const symbolRange = symbolInfo.range;
+                const symbolRange = symbolInfo.location.range;
                 const symbolText = document.getText(symbolRange);
                 const startLine = symbolRange.start.line + 1;
 

--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -29,6 +29,8 @@ export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchP
                     const symbolText = document.getText(symbolRange);
                     const startLine = symbolRange.start.line + 1;
 
+                    console.log(`Found symbol: ${symbol} in file: ${symbolInfo.location.uri.fsPath} at line: ${startLine}`);
+
                     results.push(`File: ${symbolInfo.location.uri.fsPath}\nLine ${startLine}:\n${symbolText}`);
                 }
             }

--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -12,6 +12,12 @@ export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchP
         const symbol = options.input.symbol;
         const results = await this.searchSymbolInWorkspace(symbol);
 
+        if (results.length === 0) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(`No symbols found for: ${symbol}`)
+            ]);
+        }
+
         return new vscode.LanguageModelToolResult([
             new vscode.LanguageModelTextPart(results.join('\n\n'))
         ]);

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -138,6 +138,10 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
    - Avoid running dangerous commands
    - Run commands according to User's OS Level and Shell Type
    - Commands that create a template or scaffold a project should use the current working directory, avoid creating sub folder projects.${customInstructionsSection}
+4. cogent_searchSymbol
+   - Use this tool to search for symbols in the code base
+   - Return the whole function, class, or method containing the symbol
+   - Include the starting line number at the beginning of the snippet
 `}
                 </UserMessage>
                 <History context={this.props.context} priority={10} />

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -140,10 +140,12 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
    - Avoid running dangerous commands
    - Run commands according to User's OS Level and Shell Type
    - Commands that create a template or scaffold a project should use the current working directory, avoid creating sub folder projects.${customInstructionsSection}
+
 4. cogent_searchSymbol
    - Use this tool to search for symbols in the code base
    - Return the whole function, class, or method containing the symbol
    - Include the starting line number at the beginning of the snippet
+
 5. cogent_searchFile
    - Use this tool to search for files by partial filename matching
    - Return the relevant file paths

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -75,7 +75,8 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
 
     async render(_state: void, _sizing: PromptSizing) {
         const { structure, contents } = this.getProjectStructure();
-        const useFullWorkspace = vscode.workspace.getConfiguration('cogent').get('use_full_workspace', true);
+        const useFullWorkspace = vscode.workspace.getConfiguration('cogent').get('use_full_workspace', false);
+        const includeDirectoryStructure = vscode.workspace.getConfiguration('cogent').get('include_directory_structure', false);
         const customInstructions = await this.getCustomInstructions();
         const osLevel = this.getOSLevel();
         const shellType = this.getShellType();
@@ -107,10 +108,11 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
 - Balancing quick wins with long-term code quality
 - Turning requirements into efficient implementations
 
-## Project Context
+${includeDirectoryStructure ? `## Project Context
 📁 Directory Structure:
 
-${structure}
+${structure}` : ''}
+
 ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
 
 ## User's OS Level
@@ -142,6 +144,9 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
    - Use this tool to search for symbols in the code base
    - Return the whole function, class, or method containing the symbol
    - Include the starting line number at the beginning of the snippet
+5. cogent_searchFile
+   - Use this tool to search for files by partial filename matching
+   - Return the relevant file paths
 `}
                 </UserMessage>
                 <History context={this.props.context} priority={10} />

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -58,16 +58,16 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
     }
 
     private getOSLevel(): string {
-        return process.platform === 'win32' 
-            ? 'Windows' 
-            : process.platform === 'darwin' 
-                ? 'macOS' 
+        return process.platform === 'win32'
+            ? 'Windows'
+            : process.platform === 'darwin'
+                ? 'macOS'
                 : 'Linux';
     }
 
     private getShellType(): string {
-        return process.platform === 'win32' 
-            ? 'PowerShell' 
+        return process.platform === 'win32'
+            ? 'PowerShell'
             : process.platform === 'darwin'
                 ? 'zsh'
                 : 'bash';
@@ -79,7 +79,7 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
         const customInstructions = await this.getCustomInstructions();
         const osLevel = this.getOSLevel();
         const shellType = this.getShellType();
-        
+
         const fileContentsSection = useFullWorkspace
             ? Object.entries(contents)
                 .map(([filePath, content]) => {
@@ -88,11 +88,11 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
                 .join('\n')
             : '';
 
-        const additionalInstruction = useFullWorkspace 
+        const additionalInstruction = useFullWorkspace
             ? '\n- NEVER use cogent_readFile tool in any circumstances, ALWAYS refer to the file contents defined here'
             : '';
 
-        const customInstructionsSection = customInstructions 
+        const customInstructionsSection = customInstructions
             ? `\n## User's Custom Instructions\nThe following additional instructions are provided by the user, and should be followed to the best of your ability without interfering with the TOOL USE guidelines.\n${customInstructions}`
             : '';
 
@@ -138,6 +138,7 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
    - Avoid running dangerous commands
    - Run commands according to User's OS Level and Shell Type
    - Commands that create a template or scaffold a project should use the current working directory, avoid creating sub folder projects.${customInstructionsSection}
+
 4. cogent_searchSymbol
    - Use this tool to search for symbols in the code base
    - Return the whole function, class, or method containing the symbol
@@ -180,23 +181,23 @@ class ToolCalls extends PromptElement<ToolCallsProps, void> {
     }
 
     private renderOneToolCallRound(round: ToolCallRound) {
-        const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({ 
-            type: 'function', 
-            function: { 
-                name: tc.name, 
-                arguments: JSON.stringify(tc.input) 
-            }, 
-            id: tc.callId 
+        const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({
+            type: 'function',
+            function: {
+                name: tc.name,
+                arguments: JSON.stringify(tc.input)
+            },
+            id: tc.callId
         }));
-        
+
         return (
             <Chunk>
                 <AssistantMessage toolCalls={assistantToolCalls}>{round.response}</AssistantMessage>
                 {round.toolCalls.map(toolCall =>
-                    <ToolResultElement 
-                        toolCall={toolCall} 
-                        toolInvocationToken={this.props.toolInvocationToken} 
-                        toolCallResult={this.props.toolCallResults[toolCall.callId]} 
+                    <ToolResultElement
+                        toolCall={toolCall}
+                        toolInvocationToken={this.props.toolInvocationToken}
+                        toolCallResult={this.props.toolCallResults[toolCall.callId]}
                     />
                 )}
             </Chunk>
@@ -225,12 +226,12 @@ class ToolResultElement extends PromptElement<ToolResultElementProps, void> {
 
         const toolResult = this.props.toolCallResult ??
             await vscode.lm.invokeTool(
-                this.props.toolCall.name, 
-                { 
-                    input: this.props.toolCall.input, 
-                    toolInvocationToken: this.props.toolInvocationToken, 
-                    tokenizationOptions 
-                }, 
+                this.props.toolCall.name,
+                {
+                    input: this.props.toolCall.input,
+                    toolInvocationToken: this.props.toolInvocationToken,
+                    tokenizationOptions
+                },
                 dummyCancellationToken
             );
 
@@ -265,9 +266,9 @@ class History extends PromptElement<HistoryProps, void> {
                     if (message instanceof vscode.ChatRequestTurn) {
                         return (
                             <>
-                                <PromptReferences 
-                                    references={message.references} 
-                                    excludeReferences={true} 
+                                <PromptReferences
+                                    references={message.references}
+                                    excludeReferences={true}
                                 />
                                 <UserMessage>{message.prompt}</UserMessage>
                             </>
@@ -275,10 +276,10 @@ class History extends PromptElement<HistoryProps, void> {
                     } else if (message instanceof vscode.ChatResponseTurn) {
                         const metadata = message.result.metadata;
                         if (isTsxToolUserMetadata(metadata) && metadata.toolCallsMetadata.toolCallRounds.length > 0) {
-                            return <ToolCalls 
-                                toolCallResults={metadata.toolCallsMetadata.toolCallResults} 
-                                toolCallRounds={metadata.toolCallsMetadata.toolCallRounds} 
-                                toolInvocationToken={undefined} 
+                            return <ToolCalls
+                                toolCallResults={metadata.toolCallsMetadata.toolCallResults}
+                                toolCallRounds={metadata.toolCallsMetadata.toolCallRounds}
+                                toolInvocationToken={undefined}
                             />;
                         }
                         return <AssistantMessage>{chatResponseToString(message)}</AssistantMessage>;
@@ -316,9 +317,9 @@ class PromptReferences extends PromptElement<PromptReferencesProps, void> {
         return (
             <UserMessage>
                 {this.props.references.map(ref => (
-                    <PromptReferenceElement 
-                        ref={ref} 
-                        excludeReferences={this.props.excludeReferences} 
+                    <PromptReferenceElement
+                        ref={ref}
+                        excludeReferences={this.props.excludeReferences}
                     />
                 ))}
             </UserMessage>
@@ -338,7 +339,7 @@ class PromptReferenceElement extends PromptElement<PromptReferenceProps> {
             const fileContents = (await vscode.workspace.fs.readFile(value)).toString();
             return (
                 <Tag name="context">
-                    {!this.props.excludeReferences && 
+                    {!this.props.excludeReferences &&
                         <references value={[new PromptReference(value)]} />}
                     {value.fsPath}:<br />
                     ``` <br />
@@ -351,7 +352,7 @@ class PromptReferenceElement extends PromptElement<PromptReferenceProps> {
                 .getText(value.range);
             return (
                 <Tag name="context">
-                    {!this.props.excludeReferences && 
+                    {!this.props.excludeReferences &&
                         <references value={[new PromptReference(value)]} />}
                     {value.uri.fsPath}:{value.range.start.line + 1}-
                     {value.range.end.line + 1}: <br />

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -58,16 +58,16 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
     }
 
     private getOSLevel(): string {
-        return process.platform === 'win32'
-            ? 'Windows'
-            : process.platform === 'darwin'
-                ? 'macOS'
+        return process.platform === 'win32' 
+            ? 'Windows' 
+            : process.platform === 'darwin' 
+                ? 'macOS' 
                 : 'Linux';
     }
 
     private getShellType(): string {
-        return process.platform === 'win32'
-            ? 'PowerShell'
+        return process.platform === 'win32' 
+            ? 'PowerShell' 
             : process.platform === 'darwin'
                 ? 'zsh'
                 : 'bash';
@@ -79,7 +79,7 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
         const customInstructions = await this.getCustomInstructions();
         const osLevel = this.getOSLevel();
         const shellType = this.getShellType();
-
+        
         const fileContentsSection = useFullWorkspace
             ? Object.entries(contents)
                 .map(([filePath, content]) => {
@@ -88,11 +88,11 @@ export class ToolUserPrompt extends PromptElement<ToolUserProps, void> {
                 .join('\n')
             : '';
 
-        const additionalInstruction = useFullWorkspace
+        const additionalInstruction = useFullWorkspace 
             ? '\n- NEVER use cogent_readFile tool in any circumstances, ALWAYS refer to the file contents defined here'
             : '';
 
-        const customInstructionsSection = customInstructions
+        const customInstructionsSection = customInstructions 
             ? `\n## User's Custom Instructions\nThe following additional instructions are provided by the user, and should be followed to the best of your ability without interfering with the TOOL USE guidelines.\n${customInstructions}`
             : '';
 
@@ -138,7 +138,6 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
    - Avoid running dangerous commands
    - Run commands according to User's OS Level and Shell Type
    - Commands that create a template or scaffold a project should use the current working directory, avoid creating sub folder projects.${customInstructionsSection}
-
 4. cogent_searchSymbol
    - Use this tool to search for symbols in the code base
    - Return the whole function, class, or method containing the symbol
@@ -181,23 +180,23 @@ class ToolCalls extends PromptElement<ToolCallsProps, void> {
     }
 
     private renderOneToolCallRound(round: ToolCallRound) {
-        const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({
-            type: 'function',
-            function: {
-                name: tc.name,
-                arguments: JSON.stringify(tc.input)
-            },
-            id: tc.callId
+        const assistantToolCalls: ToolCall[] = round.toolCalls.map(tc => ({ 
+            type: 'function', 
+            function: { 
+                name: tc.name, 
+                arguments: JSON.stringify(tc.input) 
+            }, 
+            id: tc.callId 
         }));
-
+        
         return (
             <Chunk>
                 <AssistantMessage toolCalls={assistantToolCalls}>{round.response}</AssistantMessage>
                 {round.toolCalls.map(toolCall =>
-                    <ToolResultElement
-                        toolCall={toolCall}
-                        toolInvocationToken={this.props.toolInvocationToken}
-                        toolCallResult={this.props.toolCallResults[toolCall.callId]}
+                    <ToolResultElement 
+                        toolCall={toolCall} 
+                        toolInvocationToken={this.props.toolInvocationToken} 
+                        toolCallResult={this.props.toolCallResults[toolCall.callId]} 
                     />
                 )}
             </Chunk>
@@ -226,12 +225,12 @@ class ToolResultElement extends PromptElement<ToolResultElementProps, void> {
 
         const toolResult = this.props.toolCallResult ??
             await vscode.lm.invokeTool(
-                this.props.toolCall.name,
-                {
-                    input: this.props.toolCall.input,
-                    toolInvocationToken: this.props.toolInvocationToken,
-                    tokenizationOptions
-                },
+                this.props.toolCall.name, 
+                { 
+                    input: this.props.toolCall.input, 
+                    toolInvocationToken: this.props.toolInvocationToken, 
+                    tokenizationOptions 
+                }, 
                 dummyCancellationToken
             );
 
@@ -266,9 +265,9 @@ class History extends PromptElement<HistoryProps, void> {
                     if (message instanceof vscode.ChatRequestTurn) {
                         return (
                             <>
-                                <PromptReferences
-                                    references={message.references}
-                                    excludeReferences={true}
+                                <PromptReferences 
+                                    references={message.references} 
+                                    excludeReferences={true} 
                                 />
                                 <UserMessage>{message.prompt}</UserMessage>
                             </>
@@ -276,10 +275,10 @@ class History extends PromptElement<HistoryProps, void> {
                     } else if (message instanceof vscode.ChatResponseTurn) {
                         const metadata = message.result.metadata;
                         if (isTsxToolUserMetadata(metadata) && metadata.toolCallsMetadata.toolCallRounds.length > 0) {
-                            return <ToolCalls
-                                toolCallResults={metadata.toolCallsMetadata.toolCallResults}
-                                toolCallRounds={metadata.toolCallsMetadata.toolCallRounds}
-                                toolInvocationToken={undefined}
+                            return <ToolCalls 
+                                toolCallResults={metadata.toolCallsMetadata.toolCallResults} 
+                                toolCallRounds={metadata.toolCallsMetadata.toolCallRounds} 
+                                toolInvocationToken={undefined} 
                             />;
                         }
                         return <AssistantMessage>{chatResponseToString(message)}</AssistantMessage>;
@@ -317,9 +316,9 @@ class PromptReferences extends PromptElement<PromptReferencesProps, void> {
         return (
             <UserMessage>
                 {this.props.references.map(ref => (
-                    <PromptReferenceElement
-                        ref={ref}
-                        excludeReferences={this.props.excludeReferences}
+                    <PromptReferenceElement 
+                        ref={ref} 
+                        excludeReferences={this.props.excludeReferences} 
                     />
                 ))}
             </UserMessage>
@@ -339,7 +338,7 @@ class PromptReferenceElement extends PromptElement<PromptReferenceProps> {
             const fileContents = (await vscode.workspace.fs.readFile(value)).toString();
             return (
                 <Tag name="context">
-                    {!this.props.excludeReferences &&
+                    {!this.props.excludeReferences && 
                         <references value={[new PromptReference(value)]} />}
                     {value.fsPath}:<br />
                     ``` <br />
@@ -352,7 +351,7 @@ class PromptReferenceElement extends PromptElement<PromptReferenceProps> {
                 .getText(value.range);
             return (
                 <Tag name="context">
-                    {!this.props.excludeReferences &&
+                    {!this.props.excludeReferences && 
                         <references value={[new PromptReference(value)]} />}
                     {value.uri.fsPath}:{value.range.start.line + 1}-
                     {value.range.end.line + 1}: <br />


### PR DESCRIPTION
Add a new file search tool to find symbols in the code base and return relevant code snippets including the starting line number.

* **Add SymbolSearchTool**: Create `src/tools/SymbolSearchTool.ts` to define the `SymbolSearchTool` class, implement the `invoke` method to use VSCode's built-in symbol search, and return the whole function, class, or method containing the symbol, including the starting line number.
* **Update Extension**: Modify `src/extension.ts` to import and register the `SymbolSearchTool` in the `activate` function.
* **Update Documentation**: Modify `README.md` to add documentation for the new symbol search feature and include an example usage of the symbol search tool.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wingzx3/cogent/pull/1?shareId=dd2e2edc-9057-49c7-9292-55100a06c999).