### PR TITLE
Update file tool to use patch format

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,22 @@ You: "@Cogent Search for files with the name 'utils'"
 Cogent: "I'll search for files with the name 'utils' and return relevant file paths. Here's what I found..."
 ```
 
+## 🛠️ Patch Update Example
+
+Cogent now supports patch format updates for files. Here's how you can use the `cogent_patchFile` tool with patch format updates:
+
+```json
+{
+    "name": "cogent_patchFile",
+    "input": {
+        "path": "src/exampleFile.ts",
+        "patch": "diff --git a/src/exampleFile.ts b/src/exampleFile.ts\nindex 83db48f..bf269f4 100644\n--- a/src/exampleFile.ts\n+++ b/src/exampleFile.ts\n@@ -1,6 +1,6 @@\n export function example() {\n-    console.log('Old content');\n+    console.log('New content');\n }\n"
+    }
+}
+```
+
+This will apply the specified patch to `src/exampleFile.ts`, updating only the lines that have changed.
+
 ## 🎭 Behind the Scenes
 
 Cogent is powered by the GitHub Copilot and mighty Claude-3.5-Sonnet model. It's like having a tiny developer living in your VS Code. Don't worry, we feed them virtual cookies! 🍪

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "license": "MIT",
     "publisher": "kturung",
     "repository": {
-		"type": "git",
-		"url": "https://github.com/kturung/cogent"
-	},
+        "type": "git",
+        "url": "https://github.com/kturung/cogent"
+    },
     "activationEvents": [],
     "main": "./out/extension.js",
     "contributes": {
@@ -36,17 +36,20 @@
             }
         },
         "chatParticipants": [
-      {
-        "id": "cogent.assistant",
-        "name": "cogent",
-        "description": "AI-powered development assistant",
-        "isSticky": true
-      }
-    ],
+            {
+                "id": "cogent.assistant",
+                "name": "cogent",
+                "description": "AI-powered development assistant",
+                "isSticky": true
+            }
+        ],
         "languageModelTools": [
             {
                 "name": "cogent_writeFile",
-                "tags": ["files", "create"],
+                "tags": [
+                    "files",
+                    "create"
+                ],
                 "displayName": "Create New File",
                 "modelDescription": "Create a new file in the workspace with specified content",
                 "inputSchema": {
@@ -61,14 +64,20 @@
                             "description": "The full text content to write into the file"
                         }
                     },
-                    "required": ["path", "content"]
+                    "required": [
+                        "path",
+                        "content"
+                    ]
                 }
             },
             {
                 "name": "cogent_patchFile",
-                "tags": ["files", "update"],
-                "displayName": "Update File",
-                "modelDescription": "Update an existing file in the workspace using patch format",
+                "tags": [
+                    "files",
+                    "patch"
+                ],
+                "displayName": "Patch File",
+                "modelDescription": "Patch an existing file in the workspace using standard unified diff (patch) format",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -78,15 +87,21 @@
                         },
                         "patch": {
                             "type": "string",
-                            "description": "Patch content for the file"
+                            "description": "Standard unified diff (patch)"
                         }
                     },
-                    "required": ["path", "patch"]
+                    "required": [
+                        "path",
+                        "patch"
+                    ]
                 }
             },
             {
                 "name": "cogent_runCommand",
-                "tags": ["terminal", "command"],
+                "tags": [
+                    "terminal",
+                    "command"
+                ],
                 "displayName": "Run Command",
                 "modelDescription": "Execute a command in the VS Code terminal",
                 "inputSchema": {
@@ -97,12 +112,17 @@
                             "description": "Command to execute"
                         }
                     },
-                    "required": ["command"]
+                    "required": [
+                        "command"
+                    ]
                 }
             },
             {
                 "name": "cogent_readFile",
-                "tags": ["files", "read"],
+                "tags": [
+                    "files",
+                    "read"
+                ],
                 "displayName": "Read File",
                 "modelDescription": "Read the contents of multiple files in the workspace",
                 "inputSchema": {
@@ -117,12 +137,17 @@
                             "description": "Array of file paths to read"
                         }
                     },
-                    "required": ["paths"]
+                    "required": [
+                        "paths"
+                    ]
                 }
             },
             {
                 "name": "cogent_searchSymbol",
-                "tags": ["files", "search"],
+                "tags": [
+                    "files",
+                    "search"
+                ],
                 "displayName": "Search Symbol",
                 "modelDescription": "Search for symbols in the code base and return relevant code snippets with line numbers",
                 "inputSchema": {
@@ -133,12 +158,17 @@
                             "description": "Symbol to search for"
                         }
                     },
-                    "required": ["symbol"]
+                    "required": [
+                        "symbol"
+                    ]
                 }
             },
             {
                 "name": "cogent_searchFile",
-                "tags": ["files", "search"],
+                "tags": [
+                    "files",
+                    "search"
+                ],
                 "displayName": "Search File",
                 "modelDescription": "Search for files by partial filename matching and return relevant file paths",
                 "inputSchema": {
@@ -149,7 +179,9 @@
                             "description": "Filename to search for"
                         }
                     },
-                    "required": ["filename"]
+                    "required": [
+                        "filename"
+                    ]
                 }
             }
         ]
@@ -166,14 +198,15 @@
         "@vscode/prompt-tsx": "^0.3.0-alpha.12"
     },
     "devDependencies": {
+        "@types/diff": "^6.0.0",
+        "@types/mocha": "^10.0.9",
         "@types/node": "^20.17.10",
         "@types/vscode": "^1.95.0",
-        "@types/mocha": "^10.0.9",
         "@typescript-eslint/eslint-plugin": "^8.10.0",
         "@typescript-eslint/parser": "^8.7.0",
-        "eslint": "^9.13.0",
-        "typescript": "^5.6.3",
         "@vscode/test-cli": "^0.0.10",
-        "@vscode/test-electron": "^2.4.1"
+        "@vscode/test-electron": "^2.4.1",
+        "eslint": "^9.13.0",
+        "typescript": "^5.6.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
                 }
             },
             {
-                "name": "cogent_updateFile",
+                "name": "cogent_patchFile",
                 "tags": ["files", "update"],
                 "displayName": "Update File",
-                "modelDescription": "Update an existing file in the workspace with new content",
+                "modelDescription": "Update an existing file in the workspace using patch format",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -76,12 +76,12 @@
                             "type": "string",
                             "description": "Relative path to the file"
                         },
-                        "content": {
+                        "patch": {
                             "type": "string",
-                            "description": "New content for the file"
+                            "description": "Patch content for the file"
                         }
                     },
-                    "required": ["path", "content"]
+                    "required": ["path", "patch"]
                 }
             },
             {

--- a/src/components/DiffView.ts
+++ b/src/components/DiffView.ts
@@ -16,7 +16,7 @@ export class DiffView {
     constructor(filePath: string, originalContent: string) {
         this.originalUri = vscode.Uri.file(filePath);
         this.modifiedUri = this.originalUri.with({ scheme: DiffView.scheme });
-        
+
         // Initialize static content provider if not exists
         if (!DiffView.contentProvider) {
             DiffView.contentProvider = {
@@ -30,7 +30,7 @@ export class DiffView {
                 DiffView.contentProvider
             );
         }
-        
+
         // Store the original content
         DiffView.content.set(this.modifiedUri.toString(), originalContent);
     }
@@ -39,7 +39,7 @@ export class DiffView {
         try {
             // Open the file first
             this.document = await vscode.workspace.openTextDocument(this.originalUri);
-            
+
             // Add save listener
             this.disposables.push(
                 vscode.workspace.onDidSaveTextDocument(async doc => {
@@ -54,7 +54,7 @@ export class DiffView {
                     }
                 })
             );
-            
+
             // Show diff editor
             await vscode.commands.executeCommand('vscode.diff',
                 this.modifiedUri,
@@ -78,7 +78,7 @@ export class DiffView {
             0, 0,
             this.document.lineCount, 0
         );
-        
+
         edit.replace(this.originalUri, fullRange, content);
         await vscode.workspace.applyEdit(edit);
     }
@@ -89,7 +89,7 @@ export class DiffView {
         const originalContent = this.document.getText();
         const patchedContent = applyPatch(originalContent, patch);
 
-        if (patchedContent.length === 0) {
+        if (patchedContent === false) {
             throw new Error('Failed to apply patch');
         }
 

--- a/src/components/DiffView.ts
+++ b/src/components/DiffView.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { applyPatch } from 'diff';
 
 export class DiffView {
     private static readonly scheme = 'cogent-diff';
@@ -80,6 +81,19 @@ export class DiffView {
         
         edit.replace(this.originalUri, fullRange, content);
         await vscode.workspace.applyEdit(edit);
+    }
+
+    async applyPatch(patch: string) {
+        if (!this.document) return;
+
+        const originalContent = this.document.getText();
+        const patchedContent = applyPatch(originalContent, patch);
+
+        if (patchedContent.length === 0) {
+            throw new Error('Failed to apply patch');
+        }
+
+        await this.update(patchedContent, 0);
     }
 
     async close() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { registerToolUserChatParticipant } from './toolParticipant';
-import { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool } from './tools';
+import { FileReadTool, FileWriteTool, FilePatchTool, CommandRunTool } from './tools';
 import { DiffView } from './components/DiffView';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
 import { FileSearchTool } from './tools/FileSearchTool';
@@ -12,7 +12,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(
         vscode.lm.registerTool('cogent_readFile', new FileReadTool()),
         vscode.lm.registerTool('cogent_writeFile', new FileWriteTool()),
-        vscode.lm.registerTool('cogent_updateFile', new FileUpdateTool()),
+        vscode.lm.registerTool('cogent_patchFile', new FilePatchTool()),
         vscode.lm.registerTool('cogent_runCommand', new CommandRunTool()),
         vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool()),
         vscode.lm.registerTool('cogent_searchFile', new FileSearchTool())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { FileSearchTool } from './tools/FileSearchTool';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Cogent extension is now active!');
-    
+
     // Register tools
     context.subscriptions.push(
         vscode.lm.registerTool('cogent_readFile', new FileReadTool()),
@@ -17,7 +17,7 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool()),
         vscode.lm.registerTool('cogent_searchFile', new FileSearchTool())
     );
-    
+
     // Register the tool participant
     registerToolUserChatParticipant(context);
 }

--- a/src/toolParticipant.ts
+++ b/src/toolParticipant.ts
@@ -82,7 +82,7 @@ export function registerToolUserChatParticipant(context: vscode.ExtensionContext
                     stream.markdown(part.value);
                     responseStr += part.value;
                 } else if (part instanceof vscode.LanguageModelToolCallPart) {
-                    if (part.name === 'cogent_updateFile') {
+                    if (part.name === 'cogent_patchFile') {
                         hasFileUpdateCall = true;
                     }
                     if (part.name === 'cogent_readFile') {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,8 +1,8 @@
 import { FileReadTool } from './tools/FileReadTool';
 import { FileWriteTool } from './tools/FileWriteTool';
-import { FileUpdateTool } from './tools/FileUpdateTool';
+import { FilePatchTool } from './tools/FilePatchTool';
 import { CommandRunTool } from './tools/CommandRunTool';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
 import { FileSearchTool } from './tools/FileSearchTool';
 
-export { FileReadTool, FileWriteTool, FileUpdateTool, CommandRunTool, SymbolSearchTool, FileSearchTool };
+export { FileReadTool, FileWriteTool, FilePatchTool, CommandRunTool, SymbolSearchTool, FileSearchTool };

--- a/src/tools/FilePatchTool.ts
+++ b/src/tools/FilePatchTool.ts
@@ -63,8 +63,9 @@ export class FilePatchTool implements vscode.LanguageModelTool<IFileOperationPar
     }
 
     private applyPatch(originalContent: string, patch: string): string {
+        console.log( `Applying patch:\n ${patch}` );
         const patchResult = applyPatch(originalContent, patch);
-        if (patchResult.length === 0) {
+        if (patchResult === false) {
             throw new Error('Failed to apply patch');
         }
         return patchResult;

--- a/src/tools/FileUpdateTool.ts
+++ b/src/tools/FileUpdateTool.ts
@@ -2,14 +2,15 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { DiffView } from '../components/DiffView';
+import { applyPatch } from 'diff';
 
 interface IFileOperationParams {
     path?: string;
     paths?: string[];
-    content?: string;
+    patch?: string;
 }
 
-export class FileUpdateTool implements vscode.LanguageModelTool<IFileOperationParams> {
+export class FilePatchTool implements vscode.LanguageModelTool<IFileOperationParams> {
     private diffView?: DiffView;
 
     async invoke(
@@ -30,15 +31,9 @@ export class FileUpdateTool implements vscode.LanguageModelTool<IFileOperationPa
             this.diffView = new DiffView(filePath, originalContent);
             await this.diffView.show();
 
-            if (options.input.content) {
-                const lines = options.input.content.split('\n');
-                for (let i = 0; i < lines.length; i++) {
-                    await this.diffView.update(
-                        lines.slice(0, i + 1).join('\n'),
-                        i
-                    );
-                    await new Promise(resolve => setTimeout(resolve, 50));
-                }
+            if (options.input.patch) {
+                const updatedContent = this.applyPatch(originalContent, options.input.patch);
+                await this.diffView.update(updatedContent, 0);
             }
 
             return new vscode.LanguageModelToolResult([
@@ -65,5 +60,13 @@ export class FileUpdateTool implements vscode.LanguageModelTool<IFileOperationPa
                 message: new vscode.MarkdownString(`Update contents of ${options.input.path}?`)
             }
         };
+    }
+
+    private applyPatch(originalContent: string, patch: string): string {
+        const patchResult = applyPatch(originalContent, patch);
+        if (patchResult.length === 0) {
+            throw new Error('Failed to apply patch');
+        }
+        return patchResult;
     }
 }

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -126,10 +126,8 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
 - Ask for clarification if requirements are unclear${additionalInstruction}
 
 ## Tool Use Instructions
-1. cogent_updateFile
-   - MUST provide complete file content
-   - No partial updates or placeholder comments
-   - Include ALL existing code when updating
+1. cogent_patchFile
+   - MUST provide in patch format.
 
 2. cogent_writeFile
    - MUST provide complete new file content

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -127,7 +127,30 @@ ${useFullWorkspace ? `\n📄 File Contents:\n${fileContentsSection}` : ''}
 
 ## Tool Use Instructions
 1. cogent_patchFile
-   - MUST provide in patch format.
+* You must provide your output in a standard unified diff (patch) format.
+* Example Patch Format
+### Below is a minimal example showing how to change the text in a file.
+
+\`\`\`diff
+@@ -1,7 +1,6 @@
+-The Way that can be told of is not the eternal Way;
+-The name that can be named is not the eternal name.
+ The Nameless is the origin of Heaven and Earth;
+-The Named is the mother of all things.
++The named is the mother of all things.
++
+ Therefore let there always be non-being,
+   so we may see their subtlety,
+ And let there always be being,
+@@ -9,3 +8,6 @@
+ The two are the same,
+ But after they are produced,
+   they have different names.
++They both may be called deep and profound.
++Deeper and more profound,
++The door of all subtleties!
+\`\`\`
+When providing a patch for cogent_patchFile, follow this structure.
 
 2. cogent_writeFile
    - MUST provide complete new file content


### PR DESCRIPTION
Implement patch format updates for the file update tool.

* **package.json**
  - Rename `cogent_updateFile` to `cogent_patchFile`.
  - Update the tool description to mention patch format updates.
  - Modify the `inputSchema` to use a `patch` property instead of the `contents` property.

* **src/tools/FileUpdateTool.ts**
  - Rename the class from `FileUpdateTool` to `FilePatchTool`.
  - Modify the `invoke` method to handle patch format updates.
  - Add a helper function to apply patch updates to the file content.

* **src/components/DiffView.ts**
  - Update the `DiffView` class to handle patch format updates.
  - Add a method to apply patch updates.

* **README.md**
  - Update the documentation to reflect the new patch update functionality.
  - Add an example of using the `cogent_patchFile` tool with patch format updates.

* **src/toolsPrompt.tsx**
  - Modify the prompt to reflect the changes to the `cogent_patchFile` tool, mentioning the use of patch format updates.

* **src/toolParticipant.ts**
  - Update the tool name from `cogent_updateFile` to `cogent_patchFile`.

* **src/extension.ts**
  - Update the tool name from `cogent_updateFile` to `cogent_patchFile`.

