### PR TITLE
Enhance symbol search with reference provider

### DIFF
--- a/src/tools/SymbolSearchTool.ts
+++ b/src/tools/SymbolSearchTool.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Location, Position } from 'vscode';
 
 interface ISymbolSearchParams {
     symbol: string;
@@ -38,7 +39,30 @@ export class SymbolSearchTool implements vscode.LanguageModelTool<ISymbolSearchP
                     console.log(`Found symbol: ${symbol} in file: ${symbolInfo.location.uri.fsPath} at line: ${startLine}`);
 
                     results.push(`File: ${symbolInfo.location.uri.fsPath}\nLine ${startLine}:\n${symbolText}`);
+
+                    const references = await this.findReferences(symbolInfo.location);
+                    results.push(...references);
                 }
+            }
+        }
+
+        return results;
+    }
+
+    private async findReferences(location: Location): Promise<string[]> {
+        const results: string[] = [];
+        const references = await vscode.commands.executeCommand<Location[]>('vscode.executeReferenceProvider', location.uri, new Position(location.range.start.line, location.range.start.character));
+
+        if (references) {
+            for (const reference of references) {
+                const document = await vscode.workspace.openTextDocument(reference.uri);
+                const referenceRange = reference.range;
+                const referenceText = document.getText(referenceRange);
+                const startLine = referenceRange.start.line + 1;
+
+                console.log(`Found reference in file: ${reference.uri.fsPath} at line: ${startLine}`);
+
+                results.push(`Reference in file: ${reference.uri.fsPath}\nLine ${startLine}:\n${referenceText}`);
             }
         }
 


### PR DESCRIPTION
Add the use of `executeReferenceProvider` to find all references to the symbol in addition to the current symbol search.

* Import `Location` and `Position` from `vscode`.
* Update `searchSymbolInWorkspace` to call `findReferences` and combine results.
* Add a private method `findReferences` to find all references to a symbol.
* Update the return format to include both symbol definitions and references.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wingzx3/cogent/pull/4?shareId=f14bccd8-6747-4b17-9cd2-8206ed741208).