### PR TITLE
Update read file tool to allow reading partial file

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ You: "@Cogent Search for files with the name 'utils'"
 Cogent: "I'll search for files with the name 'utils' and return relevant file paths. Here's what I found..."
 ```
 
+```
+You: "@Cogent Read the contents of 'src/exampleFile.ts' from line 10 to line 20"
+Cogent: "I'll read the contents of 'src/exampleFile.ts' from line 10 to line 20 and include the starting line number in the response. Here's what I found..."
+```
+
 ## 🛠️ Patch Update Example
 
 Cogent now supports patch format updates for files. Here's how you can use the `cogent_patchFile` tool with patch format updates:

--- a/package.json
+++ b/package.json
@@ -135,6 +135,14 @@
                                 "description": "Relative path to the file"
                             },
                             "description": "Array of file paths to read"
+                        },
+                        "startLine": {
+                            "type": "number",
+                            "description": "The starting line number to read from"
+                        },
+                        "endLine": {
+                            "type": "number",
+                            "description": "The ending line number to read to"
                         }
                     },
                     "required": [

--- a/src/tools/FileReadTool.ts
+++ b/src/tools/FileReadTool.ts
@@ -6,6 +6,8 @@ interface IFileOperationParams {
     path?: string;
     paths?: string[];
     content?: string;
+    startLine?: number;
+    endLine?: number;
 }
 
 export class FileReadTool implements vscode.LanguageModelTool<IFileOperationParams> {
@@ -20,16 +22,19 @@ export class FileReadTool implements vscode.LanguageModelTool<IFileOperationPara
             }
 
             const filePaths = options.input.paths || (options.input.path ? [options.input.path] : []);
+            const startLine = (options.input.startLine ?? 1) - 1; // Ensure startLine indexes from 1
+            const endLine = options.input.endLine ?? Number.MAX_SAFE_INTEGER;
 
             const results = await Promise.all(filePaths.map(async (filePath) => {
-                //const fullPath = path.join(workspacePath, filePath);
                 try {
                     const content = await fs.readFile(filePath, 'utf-8');
+                    const lines = content.split('\n').slice(startLine, endLine + 1);
                     return [
                         '=' .repeat(80),
                         `📝 File: ${filePath}`,
+                        `Starting Line: ${startLine + 1}`,
                         '=' .repeat(80),
-                        content
+                        lines.join('\n')
                     ].join('\n');
                 } catch (err) {
                     return `Error reading ${filePath}: ${(err as Error)?.message}`;

--- a/src/tools/FileReadTool.ts
+++ b/src/tools/FileReadTool.ts
@@ -29,6 +29,7 @@ export class FileReadTool implements vscode.LanguageModelTool<IFileOperationPara
                 try {
                     const content = await fs.readFile(filePath, 'utf-8');
                     const lines = content.split('\n').slice(startLine, endLine + 1);
+                    console.log( `Reading file: ${filePath} from line ${startLine + 1} to ${endLine}\n${lines.join('\n')}`);
                     return [
                         '=' .repeat(80),
                         `📝 File: ${filePath}`,

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -170,6 +170,11 @@ When providing a patch for cogent_patchFile, follow this structure.
 5. cogent_searchFile
    - Use this tool to search for files by partial filename matching
    - Return the relevant file paths
+
+6. cogent_readFile
+   - Use this tool to read the contents of files
+   - Specify start and end line numbers to read partial file content
+   - Avoid reading too many lines.  Try to keep it to less then 100 lines.  Use cogent_searchSymbol to narrow down the lines to read.
 `}
                 </UserMessage>
                 <History context={this.props.context} priority={10} />


### PR DESCRIPTION
Update the read file tool to allow reading partial file content by specifying line numbers and include the starting line number in the response.

* **package.json**
  - Add `startLine` and `endLine` properties to the `cogent_readFile` tool input schema.

* **src/tools/FileReadTool.ts**
  - Update `IFileOperationParams` interface to include `startLine` and `endLine` properties.
  - Modify `invoke` method to read partial file content based on `startLine` and `endLine`.
  - Include the starting line number in the response.
  - Ensure `startLine` indexes from 1.

* **README.md**
  - Update the `cogent_readFile` tool description to include the new functionality.

* **src/toolsPrompt.tsx**
  - Update the `ToolUserPrompt` to suggest not reading too much of a file to conserve tokens.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wingzx3/cogent/pull/5?shareId=dbba80ad-36cc-43e7-830c-63cc337abe6a).