### PR TITLE
Add text search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Before we embark on this magical journey, make sure you have:
 - 📜 **Custom Rules** - Teach your AI companion your project's special needs
 - 🔍 **Symbol Search** - Find symbols in the code base and return relevant code snippets with line numbers
 - 🔍 **File Search** - Search for files by partial filename matching and return relevant file paths
+- 🔍 **Text Search** - Search for exact text matches in workspace files
 
 ## 🚀 Installation
 
@@ -125,6 +126,11 @@ Cogent: "I'll search for files with the name 'utils' and return relevant file pa
 ```
 You: "@Cogent Read the contents of 'src/exampleFile.ts' from line 10 to line 20"
 Cogent: "I'll read the contents of 'src/exampleFile.ts' from line 10 to line 20 and include the starting line number in the response. Here's what I found..."
+```
+
+```
+You: "@Cogent Search for the text 'exampleText' in the workspace"
+Cogent: "I'll search for the text 'exampleText' in the workspace files and return the file paths and line numbers where the exact text matches are found. Here's what I found..."
 ```
 
 ## 🛠️ Patch Update Example

--- a/package.json
+++ b/package.json
@@ -32,6 +32,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Include directory structure in the prompt. If disabled, directory structure will not be included."
+                },
+                "cogent.search_include_patterns": {
+                    "type": "string",
+                    "default": "*.php,*.tpl,*.js,*.ts,*.html,*.css,*.json,*.md",
+                    "description": "Glob expression pattern to include files in search."
+                },
+                "cogent.search_exclude_patterns": {
+                    "type": "string",
+                    "default": "/node_modules,/min,*.log,*.lock",
+                    "description": "Glob expression pattern to exclude files in search."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -191,6 +191,27 @@
                         "filename"
                     ]
                 }
+            },
+            {
+                "name": "cogent_searchText",
+                "tags": [
+                    "files",
+                    "search"
+                ],
+                "displayName": "Search Text",
+                "modelDescription": "Search for exact text matches in workspace files",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "text": {
+                            "type": "string",
+                            "description": "Text to search for"
+                        }
+                    },
+                    "required": [
+                        "text"
+                    ]
+                }
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
                 },
                 "cogent.search_exclude_patterns": {
                     "type": "string",
-                    "default": "/node_modules,/min,*.log,*.lock",
+                    "default": "**/node_modules/*,**/min/**,**/dev/**",
                     "description": "Glob expression pattern to exclude files in search."
                 }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { FileReadTool, FileWriteTool, FilePatchTool, CommandRunTool } from './to
 import { DiffView } from './components/DiffView';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
 import { FileSearchTool } from './tools/FileSearchTool';
+import { TextSearchTool } from './tools/TextSearchTool';
 
 export function activate(context: vscode.ExtensionContext) {
     console.log('Cogent extension is now active!');
@@ -15,7 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.lm.registerTool('cogent_patchFile', new FilePatchTool()),
         vscode.lm.registerTool('cogent_runCommand', new CommandRunTool()),
         vscode.lm.registerTool('cogent_searchSymbol', new SymbolSearchTool()),
-        vscode.lm.registerTool('cogent_searchFile', new FileSearchTool())
+        vscode.lm.registerTool('cogent_searchFile', new FileSearchTool()),
+        vscode.lm.registerTool('cogent_searchText', new TextSearchTool())
     );
 
     // Register the tool participant

--- a/src/toolParticipant.ts
+++ b/src/toolParticipant.ts
@@ -97,6 +97,10 @@ export function registerToolUserChatParticipant(context: vscode.ExtensionContext
                         const input = part.input as { filename: string };
                         stream.markdown(`\n\nSearching for file: ${input.filename}`);
                     }
+                    if (part.name === 'cogent_searchText') {
+                        const input = part.input as { text: string };
+                        stream.markdown(`\n\nSearching for text: ${input.text}`);
+                    }
                     toolCalls.push(part);
                 }
             }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,5 +4,6 @@ import { FilePatchTool } from './tools/FilePatchTool';
 import { CommandRunTool } from './tools/CommandRunTool';
 import { SymbolSearchTool } from './tools/SymbolSearchTool';
 import { FileSearchTool } from './tools/FileSearchTool';
+import { TextSearchTool } from './tools/TextSearchTool';
 
-export { FileReadTool, FileWriteTool, FilePatchTool, CommandRunTool, SymbolSearchTool, FileSearchTool };
+export { FileReadTool, FileWriteTool, FilePatchTool, CommandRunTool, SymbolSearchTool, FileSearchTool, TextSearchTool };

--- a/src/tools/TextSearchTool.ts
+++ b/src/tools/TextSearchTool.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+
+interface ITextSearchParams {
+    text: string;
+}
+
+export class TextSearchTool implements vscode.LanguageModelTool<ITextSearchParams> {
+    async invoke(
+        options: vscode.LanguageModelToolInvocationOptions<ITextSearchParams>,
+        _token: vscode.CancellationToken
+    ) {
+        const searchText = options.input.text;
+        const results = await this.searchTextInWorkspace(searchText);
+
+        if (results.length === 0) {
+            return new vscode.LanguageModelToolResult([
+                new vscode.LanguageModelTextPart(`No matches found for: ${searchText}`)
+            ]);
+        }
+
+        return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(results.join('\n\n'))
+        ]);
+    }
+
+    private async searchTextInWorkspace(text: string): Promise<string[]> {
+        const results: string[] = [];
+        const files = await vscode.workspace.findFiles('**/*');
+
+        for (const file of files) {
+            const filePath = file.fsPath;
+            const content = await fs.readFile(filePath, 'utf-8');
+            const lines = content.split('\n');
+
+            lines.forEach((line, index) => {
+                if (line.includes(text)) {
+                    results.push(`File: ${filePath}:${index + 1}\n${line}`);
+                }
+            });
+        }
+
+        return results;
+    }
+}

--- a/src/toolsPrompt.tsx
+++ b/src/toolsPrompt.tsx
@@ -175,6 +175,10 @@ When providing a patch for cogent_patchFile, follow this structure.
    - Use this tool to read the contents of files
    - Specify start and end line numbers to read partial file content
    - Avoid reading too many lines.  Try to keep it to less then 100 lines.  Use cogent_searchSymbol to narrow down the lines to read.
+
+7. cogent_searchText
+   - Use this tool to search for exact text matches in workspace files
+   - Return the file paths and line numbers where the exact text matches are found
 `}
                 </UserMessage>
                 <History context={this.props.context} priority={10} />


### PR DESCRIPTION
Implement a new text search tool to search for exact text matches in workspace files.

* **New Tool Implementation**
  - Add `TextSearchTool` class in `src/tools/TextSearchTool.ts` to search for exact text matches in workspace files.
  - Use `vscode.workspace.findFiles` to get all files in the workspace.
  - Use `fs.promises.readFile` to read the content of each file.
  - Return the file paths and line numbers where the exact text matches are found.

* **Package Configuration**
  - Update `package.json` to add a new tool `cogent_searchText` to the `languageModelTools` section.
  - Define the input schema with a `text` property for the exact text to search.

* **Extension Activation**
  - Import `TextSearchTool` class in `src/extension.ts`.
  - Register the new tool `cogent_searchText` in the `activate` function.

* **Documentation**
  - Update `README.md` to add a new feature description for the text search tool under the "Features" section.
  - Add an example conversation for the text search tool under the "Example Conversations" section.

* **Prompt and Participant Updates**
  - Update `src/toolsPrompt.tsx` to include instructions for the new `cogent_searchText` tool.
  - Update `src/toolParticipant.ts` to add a new tool call for `cogent_searchText` in the `runWithTools` function and a new case for `cogent_searchText` in the `part.name` condition.

* **Tool Export**
  - Update `src/tools.ts` to add an export for the `TextSearchTool` class.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wingzx3/cogent/pull/6?shareId=bc195bae-f5a7-4af4-bc9d-b0bd5932f03c).